### PR TITLE
Add From Load to Render lifecycle reference

### DIFF
--- a/external-documentation-references.md
+++ b/external-documentation-references.md
@@ -52,7 +52,7 @@
 - **League of Extraordinary FoundryVTT Developers**: Discord community
 
 ### Data Lifecycle Guides
-- **From Load to Render (FoundryVTT Community Wiki)**: Step-by-step walkthrough of how a document's data travels from the world database through `Game.getData`, document constructors, the DataModel lifecycle, embedded document preparation, and finally Application V1/V2 sheet rendering hooks.
+- **From Load to Render**: https://foundryvtt.wiki/en/development/guides/from-load-to-render - Step-by-step walkthrough of how a document's data travels from the world database through `Game.getData`, document constructors, the DataModel lifecycle, embedded document preparation, and finally Application V1/V2 sheet rendering hooks.
 
 ## TypeScript and Foundry Types
 

--- a/external-documentation-references.md
+++ b/external-documentation-references.md
@@ -51,6 +51,9 @@
 - **FoundryVTT Community Wiki**: https://foundryvtt.wiki/
 - **League of Extraordinary FoundryVTT Developers**: Discord community
 
+### Data Lifecycle Guides
+- **From Load to Render (FoundryVTT Community Wiki)**: Step-by-step walkthrough of how a document's data travels from the world database through `Game.getData`, document constructors, the DataModel lifecycle, embedded document preparation, and finally Application V1/V2 sheet rendering hooks.
+
 ## TypeScript and Foundry Types
 
 ### Type Definitions

--- a/foundry-development-practices.md
+++ b/foundry-development-practices.md
@@ -169,6 +169,12 @@ TZ=America/New_York date "+%Y-%m-%d %H:%M:%S %Z"   # Full timestamp with EDT/EST
 - **Asset Management**: Proper handling of templates, styles, and static assets
 - **Canvas Integration**: Use proper layer architecture for visual elements
 
+### Document Lifecycle Checkpoints
+- **Reference**: [From Load to Render — FoundryVTT Community Wiki](https://foundryvtt.wiki/en/development/guides/from-load-to-render)
+- **Server to Client**: `Game.getData()` hydrates world collections, and document constructors run DataModel `_initializeSource` and `_initialize` to migrate, clean, and validate source data before populating live instances.
+- **Preparation Pipeline**: `ClientDocument#prepareData` defers to `prepareBaseData`, `prepareEmbeddedDocuments`, and `prepareDerivedData`—use these hooks for default state setup, active effect aggregation, and computed values instead of mutating data during sheet rendering.
+- **Sheet Rendering**: DocumentSheet (App V1) and DocumentSheetV2 rely on `getData`, `_prepareContext`, and `_preparePartContext` to build template context; keep display-only logic here and continue to route business rules through the earlier lifecycle stages.
+
 ### Known Gotchas
 - **Actor Type Namespacing**: Use full namespaced types (`'journeys-and-jamborees.party'`)
 - **Foundry Object Updates**: Use deletion syntax with `-=` prefix for removing object keys


### PR DESCRIPTION
## Summary
- add a data lifecycle resource link to the external documentation references
- summarize the document preparation and sheet rendering checkpoints in the development practices guide

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf34b3b38083279430e1cc8f80599e