### PR TITLE
docs: add clarification about module distribution model

### DIFF
--- a/automation-infrastructure.md
+++ b/automation-infrastructure.md
@@ -426,6 +426,22 @@ export default defineConfig({
 
 ## Release Management
 
+### Module Distribution Model
+
+FoundryVTT modules are **distributed software packages** installed by users into their own Foundry instances:
+
+- **Downloadable Artifacts**: Users download module.zip files from GitHub releases
+- **Local Installation**: Each user installs into their own Foundry VTT instance
+- **No Central Deployment**: There is no singular "production" environment you control
+- **User-Managed Updates**: Users must manually update to newer versions
+- **Persistence**: Released versions remain available; you cannot force rollbacks
+
+**Automation Implications**:
+- Release artifacts must be complete and self-contained
+- Automated testing must catch issues before release publication
+- CI/CD pipelines must validate thoroughly since post-release fixes require user action
+- Asset packaging must include all necessary files for standalone operation
+
 ### Semantic Versioning
 - **v0.x.x**: Development releases, breaking changes allowed
 - **v1.x.x**: Stable API, only backward-compatible changes

--- a/foundry-development-practices.md
+++ b/foundry-development-practices.md
@@ -96,6 +96,22 @@ TZ=America/New_York date "+%Y-%m-%d %H:%M:%S %Z"   # Full timestamp with EDT/EST
 
 ## Release Process
 
+### Understanding Module Distribution
+
+FoundryVTT modules are **downloadable software packages** that users install into their own Foundry instances. This distributed deployment model has critical implications:
+
+- **No Singular Production Environment**: Unlike web applications, there is no central "production" deployment that you control
+- **User-Controlled Installation**: Each user downloads and installs your module into their own Foundry VTT instance
+- **Version Diversity**: Different users may run different versions of your module simultaneously
+- **Limited Rollback**: Once users download a version, you cannot force updates or rollbacks
+- **Testing Implications**: You cannot monitor production behavior in real-time; testing must be comprehensive before release
+
+**Release Strategy Consequences**:
+- Releases must be thoroughly tested before publication
+- Breaking changes require clear migration documentation
+- Bug fixes require new releases and user action to install
+- Compatibility must be maintained across Foundry versions users may be running
+
 ### Version Management
 1. **Test Validation**: All unit and integration tests must pass
 2. **Build Verification**: Successful `npm run build` required


### PR DESCRIPTION
Explain that FoundryVTT modules are downloadable software packages installed by users into their own Foundry instances, with no singular "production" environment. Document implications for release strategy, testing, and automation.

Resolves #4

🤖 Generated with [Claude Code](https://claude.ai/code)